### PR TITLE
JEP 326 was dropped from JDK 12

### DIFF
--- a/doc/java-12.md
+++ b/doc/java-12.md
@@ -11,4 +11,3 @@ API Changes: [Diff](http://download.eclipselab.org/jdkdiff/V11/V12/index.html)
 ## Language
 
 * Switch Expressions (Preview, [JEP 325](http://openjdk.java.net/jeps/325))
-* Raw Strings, Multi Line Strings (Preview, [JEP 326](http://openjdk.java.net/jeps/326))


### PR DESCRIPTION
See https://mail.openjdk.java.net/pipermail/jdk-dev/2018-December/002469.html