### PR TITLE
Add option to show whitespace chars and use it for textblocks

### DIFF
--- a/site/assets/app/sandbox.js
+++ b/site/assets/app/sandbox.js
@@ -10,7 +10,8 @@ Vue.component('sandbox', {
     props: {
         version: { type: String, required: true },
         mainclass: { type: String, required: true },
-        preview: { type: Boolean, required: false, default: false }
+        preview: { type: Boolean, required: false, default: false },
+        showInvisibles: { type: Boolean, required: false, default: false }
     },
     data() {
         return {
@@ -45,7 +46,7 @@ Vue.component('sandbox-source', {
         </div>
     `,
     props: {
-        name: { required: true },
+        name: { required: true }
     },
     data() {
         return {
@@ -61,7 +62,9 @@ Vue.component('sandbox-source', {
             highlightActiveLine: false,
             showGutter: false,
             showPrintMargin: false,
-            maxLines: Infinity
+            maxLines: Infinity,
+            useSoftTabs: false,
+            showInvisibles: this.$parent.$parent.showInvisibles
         });
         this.editor.setValue(this.source, 1);
         this.editor.on('change', () => {

--- a/site/content/features/textblocks.md
+++ b/site/content/features/textblocks.md
@@ -368,9 +368,9 @@ In this case, the shortest whitespace prefix has length 3 (in the last line), an
 
 The third line is entirely blank because trailing whitespace is removed. Note that it doesn't matter that it only had two spaces. Entirely blank lines are ignored when measuring the indent. Except for the last one. Its whitespace is considered, before it is discarded, being a blank line preceding the closing `"""`. 
 
-I am not making this up. Here is the program. It is difficult to see the difference between the tabs and spaces, but if you copy out the contents, save to a file, and view a hex dump, you can confirm them.
+I am not making this up. Here is the program, the sandbox editor shows spaces and tabs:
 
-{{< sandbox version=java15 preview="true" mainclass="Sandbox" >}}
+{{< sandbox version=java15 preview="true" mainclass="Sandbox" show-invisibles="true">}}
 {{< sandboxsource "Sandbox.java" >}}
 public class Sandbox {
     public static void main(String[] args) {

--- a/site/content/features/textblocks.md
+++ b/site/content/features/textblocks.md
@@ -368,7 +368,7 @@ In this case, the shortest whitespace prefix has length 3 (in the last line), an
 
 The third line is entirely blank because trailing whitespace is removed. Note that it doesn't matter that it only had two spaces. Entirely blank lines are ignored when measuring the indent. Except for the last one. Its whitespace is considered, before it is discarded, being a blank line preceding the closing `"""`. 
 
-I am not making this up. Here is the program, the sandbox editor shows spaces and tabs:
+I am not making this up. Here is the program, with spaces and tabs displayed in the sandbox editor:
 
 {{< sandbox version=java15 preview="true" mainclass="Sandbox" show-invisibles="true">}}
 {{< sandboxsource "Sandbox.java" >}}

--- a/site/layouts/shortcodes/sandbox.html
+++ b/site/layouts/shortcodes/sandbox.html
@@ -1,3 +1,3 @@
-<sandbox version="{{ .Get "version"}}" mainclass="{{ .Get "mainclass"}}" {{ with .Get "preview"}} preview="{{.}}"{{ end }} v-cloak>
+<sandbox version="{{ .Get "version"}}" mainclass="{{ .Get "mainclass"}}" {{ with .Get "preview"}} preview="{{.}}"{{ end }} {{ with .Get "show-invisibles"}} v-bind:show-invisibles="{{.}}"{{ end }} v-cloak>
 {{ .Inner }}
 </sandbox>


### PR DESCRIPTION
Hi Cay, I added an option to our sandbox editor to show whitespace characters and suggest to use it at the example in your textblock article where you demonstrate whitespace processing. I also adjusted the text as it can now actually be seen.

What do you think?