### PR TITLE
Added Solaris SPARCv9 and x86_64 platforms for Liberica.

### DIFF
--- a/site/data/jdk/vendors.json
+++ b/site/data/jdk/vendors.json
@@ -89,7 +89,7 @@
 				"name": "Liberica",
 				"license": "GPLv2+CE",
 				"url": "https://bell-sw.com/java",
-				"platforms": ["linux-x86", "linux-x64", "linux-arm32", "linux-aarch64", "linux-ppc64le", "macOS-x64", "windows-x86", "windows-x64"],
+				"platforms": ["linux-x86", "linux-x64", "linux-arm32", "linux-aarch64", "linux-ppc64le", "macOS-x64", "windows-x86", "windows-x64", "solaris-sparcv9", "solaris-x64"],
 				"versions": ["8", "9", "10", "11", "12", "13", "14"]
 			}
 		]


### PR DESCRIPTION
See https://bell-sw.com/pages/supported-configurations/.