### PR TITLE
rename jdk.java.net builds

### DIFF
--- a/site/data/jdk/vendors.json
+++ b/site/data/jdk/vendors.json
@@ -96,33 +96,6 @@
 	},
 	{
 		"name": "Oracle",
-		"url": "http://jdk.java.net/",
-		"products": [
-			{
-				"name": "Oracle OpenJDK",
-				"license": "GPLv2+CE",
-				"url": "http://jdk.java.net/14/",
-				"platforms": ["linux-x64", "macOS-x64", "windows-x64"],
-				"versions": ["14"]
-			},
-			{
-				"name": "Oracle OpenJDK",
-				"license": "GPLv2+CE",
-				"url": "http://jdk.java.net/15/",
-				"platforms": ["linux-x64", "linux-aarch64", "macOS-x64", "windows-x64"],
-				"versions": ["15"]
-			},
-			{
-				"name": "Oracle OpenJDK",
-				"license": "GPLv2+CE",
-				"url": "http://jdk.java.net/16/",
-				"platforms": ["linux-x64", "linux-aarch64", "macOS-x64", "windows-x64"],
-				"versions": ["16"]
-			}
-		]
-	},
-	{
-		"name": "Oracle",
 		"url": "https://www.oracle.com/java/",
 		"products": [
 			{
@@ -228,6 +201,27 @@
 				"platforms": ["linux-x64", "macOS-x64", "windows-x64"],
 				"vms": ["HotSpot"],
 				"versions": ["14"]
+			},
+			{
+				"name": "Oracle OpenJDK",
+				"license": "GPLv2+CE",
+				"url": "http://jdk.java.net/14/",
+				"platforms": ["linux-x64", "macOS-x64", "windows-x64"],
+				"versions": ["14"]
+			},
+			{
+				"name": "Oracle OpenJDK",
+				"license": "GPLv2+CE",
+				"url": "http://jdk.java.net/15/",
+				"platforms": ["linux-x64", "linux-aarch64", "macOS-x64", "windows-x64"],
+				"versions": ["15"]
+			},
+			{
+				"name": "Oracle OpenJDK",
+				"license": "GPLv2+CE",
+				"url": "http://jdk.java.net/16/",
+				"platforms": ["linux-x64", "linux-aarch64", "macOS-x64", "windows-x64"],
+				"versions": ["16"]
 			}
 		]
 	},

--- a/site/data/jdk/vendors.json
+++ b/site/data/jdk/vendors.json
@@ -95,32 +95,32 @@
 		]
 	},
 	{
-		"name": "jdk.java.net",
+		"name": "Oracle",
 		"url": "http://jdk.java.net/",
 		"products": [
 			{
-				"name": "JDK 14 Early-Access Builds",
+				"name": "Oracle OpenJDK",
 				"license": "GPLv2+CE",
 				"url": "http://jdk.java.net/14/",
 				"platforms": ["linux-x64", "macOS-x64", "windows-x64"],
 				"versions": ["14"]
 			},
 			{
-				"name": "JDK 15 Early-Access Builds",
+				"name": "Oracle OpenJDK",
 				"license": "GPLv2+CE",
 				"url": "http://jdk.java.net/15/",
 				"platforms": ["linux-x64", "linux-aarch64", "macOS-x64", "windows-x64"],
 				"versions": ["15"]
 			},
 			{
-				"name": "JDK 16 Early-Access Builds",
+				"name": "Oracle OpenJDK",
 				"license": "GPLv2+CE",
 				"url": "http://jdk.java.net/16/",
 				"platforms": ["linux-x64", "linux-aarch64", "macOS-x64", "windows-x64"],
 				"versions": ["16"]
 			}
 		]
-	},	
+	},
 	{
 		"name": "Oracle",
 		"url": "https://www.oracle.com/java/",


### PR DESCRIPTION
Hi,

this PR adjusts vendor and product names to better reflect the reality.  

the builds from jdk.java.net are Oracle OpenJDK builds produced by Oracle. also, JDK 14 build isn't an EA build; it's GA build of JDK 14.0.2, JDK 15 build is currently RC build and is going to be GA soon-ish. as the download page clearly says the build's type right in its title when you open it, it doesn't make much sense to have build-type in the product name and update it every time it gets changed.