### PR TITLE
Switching to the commonly used name to reference the Oracle JDK builds.

### DIFF
--- a/site/data/jdk/vendors/oracle.json
+++ b/site/data/jdk/vendors/oracle.json
@@ -135,7 +135,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 8",
+			"name": "Oracle JDK 8",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/downloads/#java8",
 			"platforms": [
@@ -156,7 +156,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 9",
+			"name": "Oracle JDK 9",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/javase/javase9-archive-downloads.html",
 			"platforms": [
@@ -172,7 +172,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 10",
+			"name": "Oracle JDK 10",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/java-archive-javase10-downloads.html",
 			"platforms": [
@@ -188,7 +188,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 11",
+			"name": "Oracle JDK 11",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/downloads/#java11",
 			"platforms": [
@@ -205,7 +205,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 12",
+			"name": "Oracle JDK 12",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/javase/jdk12-archive-downloads.html",
 			"platforms": [
@@ -220,7 +220,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 13",
+			"name": "Oracle JDK 13",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/javase/jdk13-archive-downloads.html",
 			"platforms": [
@@ -235,7 +235,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 14",
+			"name": "Oracle JDK 14",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/javase/jdk14-archive-downloads.html",
 			"platforms": [
@@ -250,7 +250,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 15",
+			"name": "JOracle JDK 15",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/javase/jdk15-archive-downloads.html",
 			"platforms": [
@@ -266,7 +266,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 16",
+			"name": "Oracle JDK 16",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/downloads/#java16",
 			"platforms": [
@@ -282,7 +282,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "Java SE Development Kit 17",
+			"name": "Oracle JDK 17",
 			"license": "Oracle No-Fee",
 			"url": "https://www.oracle.com/java/technologies/downloads/#java17",
 			"platforms": [

--- a/site/data/jdk/vendors/oracle.json
+++ b/site/data/jdk/vendors/oracle.json
@@ -250,7 +250,7 @@
 		},
 		{
 			"id": "oracle",
-			"name": "JOracle JDK 15",
+			"name": "Oracle JDK 15",
 			"license": "Commercial",
 			"url": "https://www.oracle.com/java/technologies/javase/jdk15-archive-downloads.html",
 			"platforms": [


### PR DESCRIPTION
**Oracle JDK** and **Oracle OpenJDK** are the commonly used names to distinguish unambiguously the 2 JDK distributions offered by Oracle.

See for example https://blogs.oracle.com/java/post/free-java-license