### PR TITLE
SapMachine 17: remove linux-ppc64 be 

### DIFF
--- a/site/data/jdk/vendors/sap.json
+++ b/site/data/jdk/vendors/sap.json
@@ -127,7 +127,6 @@
 			"license": "GPLv2+CE",
 			"url": "https://sap.github.io/SapMachine/latest/17",
 			"platforms": [
-				"linux-ppc64",
 				"linux-ppc64le",
 				"linux-x64",
 				"macos-arm64",


### PR DESCRIPTION
Dear Marc,

thanks for running the Java Almanac and featuring our distribution. May I suggest an update with regards platform support for SapMachine; Support for linux-ppc64 big endian has been [dropped with SapMachine 17](https://github.com/SAP/SapMachine/wiki/Security-Updates,-Maintenance-and-Support).

Thanks! :) 
