### PR TITLE
Java 19 - Add JEP 405 Record Patterns (Preview)

### DIFF
--- a/site/data/jdk/versions/19.json
+++ b/site/data/jdk/versions/19.json
@@ -27,7 +27,7 @@
 			]
 		},
 		{
-			"title": "Record Patterns (Preview)",
+			"title": "Record Patterns",
 			"category": "lang",
 			"preview": true,
 			"refs": [

--- a/site/data/jdk/versions/19.json
+++ b/site/data/jdk/versions/19.json
@@ -27,6 +27,17 @@
 			]
 		},
 		{
+			"title": "Record Patterns (Preview)",
+			"category": "lang",
+			"preview": true,
+			"refs": [
+				{
+					"type": "JEP",
+					"identifier": "405"
+				}
+			]
+		},
+		{
 			"title": "Pattern Matching for switch (Third Preview)",
 			"category": "lang",
 			"preview": true,


### PR DESCRIPTION
According to https://openjdk.org/projects/jdk/19/ JEP 405 is part of Java 19 as well.