### PR TITLE
Fix typesetting of "GitHub" and "Hugo"

### DIFF
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -20,7 +20,7 @@ Collection of information about the history and future of Java.
 ## About
 
 This site is provided by Java Champions Marc R. Hoffmann and Cay S. Horstmann.
-All content is managed in a [public Github repository](https://github.com/marchof/java-almanac).
+All content is managed in a [public GitHub repository](https://github.com/marchof/java-almanac).
 The structured data about the JDK is also available via an [open API](https://editor.swagger.io/?url=https://data.javaalmanac.io/v1/openapi.yaml).
 
 

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -2,8 +2,8 @@
 <div class="footer-bar">
 <div class="footer">
   <span style="float:right">&copy; 2018, {{ now.Year }} Marc R. Hoffmann et al. <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a></span>
-  Content managed on <a href="https://github.com/marchof/java-almanac">Github</a>.
-  Generated with <a href="https://gohugo.io/">HUGO</a>.
+  Content managed on <a href="https://github.com/marchof/java-almanac">GitHub</a>.
+  Generated with <a href="https://gohugo.io/">Hugo</a>.
   Collected with passion.
 </div>
 </div>


### PR DESCRIPTION
Follow the official typesetting:
- https://github.com/about
- https://github.com/gohugoio/hugo#overview