### PR TITLE
Java 26: Add JEP 530 for Primitive Types in Patterns (Preview)

### DIFF
--- a/data/jdk/versions/26.json
+++ b/data/jdk/versions/26.json
@@ -81,6 +81,18 @@
 					"identifier": "522"
 				}
 			]
+		},
+		{
+			"title": "Primitive Types in Patterns, instanceof, and switch",
+			"category": "lang",
+			"preview": true,
+			"revision": 4,
+			"refs": [
+				{
+					"type": "JEP",
+					"identifier": "530"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
See https://openjdk.org/projects/jdk/26/, JEP 530 is part of Java 26