### PR TITLE
fix: restore sandbox Run requests

### DIFF
--- a/.hugo/assets/app/sandbox.js
+++ b/.hugo/assets/app/sandbox.js
@@ -43,7 +43,7 @@ Vue.component('sandbox', {
                     sourcefiles.push({name: tab.name, content: tab.source});
                 }
             });
-            request = {
+            const request = {
                 mainclass: this.mainclass || this.mainsource,
                 preview: this.preview,
                 sourcefiles: sourcefiles


### PR DESCRIPTION
## Summary

- Declare the sandbox POST payload as a local constant.

## Root cause

The sandbox script runs in strict mode. Assigning an undeclared request identifier throws before the network call, so Run cannot execute a sandbox.

## Validation

- Parsed the edited JavaScript with Node.
- Exercised the Run method in a Node VM and verified its endpoint and POST payload.
