### PR TITLE
fix: correct Temurin 26 product link

### DIFF
--- a/data/jdk/vendors/adoptium.json
+++ b/data/jdk/vendors/adoptium.json
@@ -278,7 +278,7 @@
 			"id": "temurin",
 			"name": "Eclipse Temurin",
 			"license": "GPLv2+CE",
-			"url": "https://adoptium.net/temurin/releases/?version\u003d25",
+			"url": "https://adoptium.net/temurin/releases/?version\u003d26",
 			"platforms": [
 				"aix-ppc64",
 				"alpine-arm64",


### PR DESCRIPTION
## Summary

- Correct the Eclipse Temurin product link for Java 26.

## Root cause

The Temurin product entry declares Java 26 but its release URL selects Java 25. The JDK details shortcode renders that URL directly as the product link.

## Validation

- Parsed the vendor data as JSON.
- Verified that the Temurin 25 and Temurin 26 entries each select their matching release version.
- Verified that the JDK details shortcode uses the matching product URL.
